### PR TITLE
Extended determine MIME type with Marcel

### DIFF
--- a/lib/shrine/plugins/determine_mime_type.rb
+++ b/lib/shrine/plugins/determine_mime_type.rb
@@ -216,7 +216,7 @@ class Shrine
 
           return nil if io.eof? # marcel returns "application/octet-stream" for empty files
 
-          Marcel::MimeType.for(io)
+          Marcel::MimeType.for(io, name: extract_filename(io))
         end
 
         def extract_with_mime_types(io)


### PR DESCRIPTION
Marcel based on gem MimeMagic which has problems with some MS Office files: [".xls file detected as application/x-ole-storage"](https://github.com/minad/mimemagic/issues/50)

Marcel method 'for' method call with additional options 'name' resolve problem for tested files.

`Marcel::MimeType.for(pathname_or_io = nil, name: nil, extension: nil, declared_type: nil)`
